### PR TITLE
Task vectors: evaluate and optimize linear combinations of weak-to-strong checkpoints

### DIFF
--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -6,7 +6,7 @@ import torch
 from weak_to_strong.common import get_tokenizer
 from weak_to_strong.config import MODELS_DICT
 from weak_to_strong.datasets import tokenize_dataset
-from weak_to_strong.eval import eval_model_acc
+from weak_to_strong.eval import eval_model_acc, extract_accuracy, extract_ce_loss
 from train_simple import main as train_simple_main
 import fire
 
@@ -139,10 +139,10 @@ def main(
     if verbose:
         print("Evaluating model")
     test_results = eval_model_acc(model, test_ds, eval_batch_size)
-    accuracies = torch.stack([r["acc"] for r in test_results])  # type: ignore
-    test_acc = torch.mean(accuracies, dim=0)  # type: ignore
+    test_acc = extract_accuracy(test_results)
+    test_loss = extract_ce_loss(test_results)
     if verbose:
-        print(f"Test accuracy: {test_acc.item()}")
+        print(f"Test accuracy: {test_acc}")
 
     # Save results
     if store:
@@ -150,10 +150,10 @@ def main(
         with open(result_path, "r") as f:
             res_dict = json.load(f)
         key = f"task_vector_{coef_best_str}_{coef_final_str}"
-        res_dict[key] = test_acc.item()
+        res_dict[key] = test_acc
         with open(os.path.join(save_path, "results_summary.json"), "w") as f:
             json.dump(res_dict, f, indent=2)
-    return test_acc
+    return test_loss
 
 
 if __name__ == "__main__":

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -123,7 +123,7 @@ def main(
 
     if verbose:
         print(f"Loading model {model_size}")
-    model, _ = model_config.load_model(
+    model, minibatch_size = model_config.load_model(
         batch_size=eval_batch_size,
         use_lm_head=use_lm_head,
         linear_probe=linear_probe,
@@ -138,9 +138,15 @@ def main(
 
     if verbose:
         print("Evaluating model")
-        print(f"model.requires_grad={any([p.requires_grad for p in model.parameters()])}")
+        model_requires_grad = any([
+            p.requires_grad for p in model.parameters()
+        ])
+        print(f"requires_grad={model_requires_grad}")
     test_acc, test_loss = eval_model_accuracy_loss(
-        model, test_ds, eval_batch_size
+        model,
+        test_ds,
+        batch_size=eval_batch_size,
+        minibatch_size=minibatch_size,
     )
     if verbose:
         print(f"Test accuracy: {test_acc.item()}")

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -12,8 +12,8 @@ from weak_to_strong.datasets import load_and_process_dataset
 def main(
     coef_best: float,
     coef_final: float,
+    model_size: str = "mistralai/Mistral-7B-v0.1",
     weak_model_size: str = "gpt2",
-    strong_model_size: str = "mistralai/Mistral-7B-v0.1",
     ds_name: str = "sciq",
     w2s_eval_every: int = 1,
     seed: int = 0,
@@ -36,6 +36,8 @@ def main(
             Coefficient for the final model.
         model_size: str
             Model size to use.
+        weak_model_size: str
+            Weak model size to use.
         ds_name: str
             Dataset to use.
         w2s_eval_every: int
@@ -71,7 +73,7 @@ def main(
     )
     # Train strong model on weak labels
     save_path = train_simple_main(
-        model_size=strong_model_size,
+        model_size=model_size,
         weak_model_size=weak_model_size,
         ds_name=ds_name,
         w2s_eval_every=w2s_eval_every,
@@ -84,7 +86,7 @@ def main(
     )
     best_path = os.path.join(save_path, "best_model.bin")
     final_path = os.path.join(save_path, "final_model.bin")
-    model_config = MODELS_DICT[strong_model_size]
+    model_config = MODELS_DICT[model_size]
     eval_batch_size = model_config.eval_batch_size
 
     if verbose:
@@ -102,7 +104,7 @@ def main(
     use_lm_head = "choice_input_ids" in eval_ds.features
 
     if verbose:
-        print(f"Loading model {strong_model_size}")
+        print(f"Loading model {model_size}")
     model, _ = model_config.load_model(
         batch_size=eval_batch_size,
         use_lm_head=use_lm_head,

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -1,0 +1,111 @@
+import numpy as np
+import os
+from weak_to_strong.config import MODELS_DICT
+from weak_to_strong.eval import eval_model_acc
+from weak_to_strong.model import update_sharded_checkpoint
+from train_simple import main as train_simple_main
+import fire
+
+from weak_to_strong.datasets import load_and_process_dataset
+
+
+def main(
+    coef_best: float,
+    coef_final: float,
+    model_size: str = "gpt2",
+    ds_name: str = "sciq",
+    w2s_eval_every: int = 1,
+    seed: int = 0,
+    n_train1_docs: int = 1000,
+    n_train2_docs: int = 1000,
+    n_test_docs: int = 1000,
+    linear_probe: bool = False,
+    verbose: bool = False,
+    **kwargs
+) -> float:
+    """Evaluate the task vector arithmetic on ground truth labels.
+    Uses arithmetic
+        w_base +
+        coef_best * (w_best - w_base) +
+        coef_final * (w_final - w_base).
+    Arguments:
+        coef_best: float
+            Coefficient for the best model.
+        coef_final: float
+            Coefficient for the final model.
+        model_size: str
+            Model size to use.
+        ds_name: str
+            Dataset to use.
+        w2s_eval_every: int
+            How often to evaluate the model.
+        seed: int
+            Random seed.
+        n_train1_docs: int
+            Number of training documents for the first model.
+        n_train2_docs: int
+            Number of training documents for the second model.
+        n_test_docs: int
+            Number of test documents.
+        linear_probe: bool
+            Whether to use a linear probe.
+        verbose: bool
+            Whether to print verbose output.
+        **kwargs: dict
+            Other arguments to pass to train_simple_main.
+    Returns:
+        Ground truth accuracy of the new model
+    """
+    save_path = train_simple_main(
+        model_size=model_size,
+        ds_name=ds_name,
+        w2s_eval_every=w2s_eval_every,
+        seed=seed,
+        n_train1_docs=n_train1_docs,
+        n_train2_docs=n_train2_docs,
+        n_test_docs=n_test_docs,
+        linear_probe=linear_probe,
+        **kwargs,
+    )
+    best_path = os.path.join(save_path, "best_model.bin")
+    final_path = os.path.join(save_path, "final_model.bin")
+    model_config = MODELS_DICT[model_size]
+    eval_batch_size = model_config.eval_batch_size
+
+    if verbose:
+        print(f"Loading dataset {ds_name}")
+    dataset = load_and_process_dataset(
+        ds_name,
+        seed=seed,
+        split_sizes=dict(
+            train=n_train1_docs + n_train2_docs,
+            test=n_test_docs
+        ),
+    )
+
+    eval_ds = dataset["test"]  # type: ignore
+    use_lm_head = "choice_input_ids" in eval_ds.features
+
+    if verbose:
+        print(f"Loading model {model_size}")
+    model, _ = model_config.load_model(
+        batch_size=eval_batch_size,
+        use_lm_head=use_lm_head,
+        linear_probe=linear_probe,
+    )
+    if verbose:
+        print("Updating model weights")
+        print(f"coef_best={coef_best}, best_path={best_path}")
+    update_sharded_checkpoint(model, best_path, coef_best)
+    if verbose:
+        print(f"coef_final={coef_final}, final_path={final_path}")
+    update_sharded_checkpoint(model, final_path, coef_final)
+
+    test_results = eval_model_acc(model, eval_ds, eval_batch_size)
+    return float(
+        np.mean([r["acc"] for r in test_results])  # type: ignore
+    )
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -136,6 +136,10 @@ def main(
         use_lm_head=use_lm_head,
         linear_probe=linear_probe,
     )
+    print("Parameters requiring grad before disable:")
+    for name, param in model.named_parameters():
+        if param.requires_grad:
+            print(name)
     model.requires_grad_(False)  # training complete
     if verbose:
         print("Updating model weights")

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -138,6 +138,7 @@ def main(
 
     if verbose:
         print("Evaluating model")
+        print(f"model.requires_grad={any([p.requires_grad for p in model.parameters()])}")
     test_acc, test_loss = eval_model_accuracy_loss(
         model, test_ds, eval_batch_size
     )

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -6,7 +6,7 @@ import torch
 from weak_to_strong.common import get_tokenizer
 from weak_to_strong.config import MODELS_DICT
 from weak_to_strong.datasets import tokenize_dataset
-from weak_to_strong.eval import eval_model_acc, eval_model_accuracy_loss, extract_accuracy, extract_ce_loss
+from weak_to_strong.eval import eval_model_accuracy_loss
 from train_simple import main as train_simple_main
 import fire
 

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -144,16 +144,13 @@ def main(
     if verbose:
         print("Updating model weights")
         print(f"coef_best={coef_best_float}, best_path={best_path}")
-        print(f"model requires_grad={model.requires_grad}")
     model.update_state(best_path, coef_best)
     if verbose:
         print(f"coef_final={coef_final_float}, final_path={final_path}")
-        print(f"model requires_grad={model.requires_grad}")
     model.update_state(final_path, coef_final)
 
     if verbose:
         print("Evaluating model")
-        print(f"requires_grad={model.requires_grad}")
     test_acc, test_loss = eval_model_accuracy_loss(
         model,
         test_ds,

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -136,10 +136,6 @@ def main(
         use_lm_head=use_lm_head,
         linear_probe=linear_probe,
     )
-    print("Parameters requiring grad before disable:")
-    for name, param in model.named_parameters():
-        if param.requires_grad:
-            print(name)
     model.requires_grad_(False)  # training complete
     if verbose:
         print("Updating model weights")

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -69,9 +69,17 @@ def main(
     Returns:
         Ground truth accuracy of the new model
     """
-    coef_best_float = float(coef_best)
+    coef_best_float = (
+        coef_best.item()
+        if isinstance(coef_best, torch.Tensor)
+        else coef_best
+    )
     coef_best_str = f"{coef_best_float:.1f}".replace(".", "_")
-    coef_final_float = float(coef_final)
+    coef_final_float = (
+        coef_final.item()
+        if isinstance(coef_final, torch.Tensor)
+        else coef_final
+    )
     coef_final_str = f"{coef_final_float:.1f}".replace(".", "_")
     # Train weak model on ground truth
     train_simple_main(

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -138,7 +138,7 @@ def main(
     result_path = os.path.join(save_path, "results_summary.json")
     with open(result_path, "r") as f:
         res_dict = json.load(f)
-    res_dict['task_vector'] = res_dict.get('task_vector', []) + [(coef_best, coef_final, test_acc)]
+    res_dict[f"task_vector_{coef_best:.1f}_{coef_final:.1f}"] = test_acc
     with open(os.path.join(save_path, "results_summary.json"), "w") as f:
         json.dump(res_dict, f, indent=2)
     return test_acc

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -6,7 +6,7 @@ import torch
 from weak_to_strong.common import get_tokenizer
 from weak_to_strong.config import MODELS_DICT
 from weak_to_strong.datasets import tokenize_dataset
-from weak_to_strong.eval import eval_model_acc, extract_accuracy, extract_ce_loss
+from weak_to_strong.eval import eval_model_acc, eval_model_accuracy_loss, extract_accuracy, extract_ce_loss
 from train_simple import main as train_simple_main
 import fire
 
@@ -138,11 +138,11 @@ def main(
 
     if verbose:
         print("Evaluating model")
-    test_results = eval_model_acc(model, test_ds, eval_batch_size)
-    test_acc = extract_accuracy(test_results)
-    test_loss = extract_ce_loss(test_results)
+    test_acc, test_loss = eval_model_accuracy_loss(
+        model, test_ds, eval_batch_size
+    )
     if verbose:
-        print(f"Test accuracy: {test_acc}")
+        print(f"Test accuracy: {test_acc.item()}")
 
     # Save results
     if store:
@@ -150,7 +150,7 @@ def main(
         with open(result_path, "r") as f:
             res_dict = json.load(f)
         key = f"task_vector_{coef_best_str}_{coef_final_str}"
-        res_dict[key] = test_acc
+        res_dict[key] = test_acc.item()
         with open(os.path.join(save_path, "results_summary.json"), "w") as f:
             json.dump(res_dict, f, indent=2)
     return test_loss

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -136,20 +136,20 @@ def main(
         use_lm_head=use_lm_head,
         linear_probe=linear_probe,
     )
+    model.requires_grad_(False)  # training complete
     if verbose:
         print("Updating model weights")
         print(f"coef_best={coef_best_float}, best_path={best_path}")
+        print(f"model requires_grad={model.requires_grad}")
     model.update_state(best_path, coef_best)
     if verbose:
         print(f"coef_final={coef_final_float}, final_path={final_path}")
+        print(f"model requires_grad={model.requires_grad}")
     model.update_state(final_path, coef_final)
 
     if verbose:
         print("Evaluating model")
-        model_requires_grad = any([
-            p.requires_grad for p in model.parameters()
-        ])
-        print(f"requires_grad={model_requires_grad}")
+        print(f"requires_grad={model.requires_grad}")
     test_acc, test_loss = eval_model_accuracy_loss(
         model,
         test_ds,

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -29,7 +29,7 @@ def main(
     store: bool = False,
     verbose: bool = False,
     **kwargs
-) -> torch.Tensor:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Evaluate the task vector arithmetic on ground truth labels.
     Uses arithmetic
         w_base +
@@ -165,7 +165,7 @@ def main(
         res_dict[key] = test_acc.item()
         with open(os.path.join(save_path, "results_summary.json"), "w") as f:
             json.dump(res_dict, f, indent=2)
-    return test_loss
+    return test_acc, test_loss
 
 
 if __name__ == "__main__":

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -2,7 +2,6 @@ import numpy as np
 import os
 from weak_to_strong.config import MODELS_DICT
 from weak_to_strong.eval import eval_model_acc
-from weak_to_strong.model import update_model_incremental
 from train_simple import main as train_simple_main
 import fire
 

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -1,3 +1,4 @@
+import json
 import numpy as np
 import os
 from weak_to_strong.common import get_tokenizer
@@ -129,9 +130,20 @@ def main(
     if verbose:
         print("Evaluating model")
     test_results = eval_model_acc(model, test_ds, eval_batch_size)
-    return float(
-        np.mean([r["acc"] for r in test_results])  # type: ignore
-    )
+    test_acc = float(np.mean([r["acc"] for r in test_results]))  # type: ignore
+    if verbose:
+        print(f"Test accuracy: {test_acc}")
+
+    # Save results
+    result_path = os.path.join(save_path, "results_summary.json")
+    with open(result_path, "r") as f:
+        res_dict = json.load(f)
+    res_dict.update({
+        ("task_vector", coef_best, coef_final): test_acc
+    })
+    with open(os.path.join(save_path, "results_summary.json"), "w") as f:
+        json.dump(res_dict, f, indent=2)
+    return test_acc
 
 
 if __name__ == "__main__":

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -138,9 +138,7 @@ def main(
     result_path = os.path.join(save_path, "results_summary.json")
     with open(result_path, "r") as f:
         res_dict = json.load(f)
-    res_dict.update({
-        ("task_vector", coef_best, coef_final): test_acc
-    })
+    res_dict['task_vector'] = res_dict.get('task_vector', []) + [(coef_best, coef_final, test_acc)]
     with open(os.path.join(save_path, "results_summary.json"), "w") as f:
         json.dump(res_dict, f, indent=2)
     return test_acc

--- a/evaluate_task_vector.py
+++ b/evaluate_task_vector.py
@@ -2,7 +2,7 @@ import numpy as np
 import os
 from weak_to_strong.config import MODELS_DICT
 from weak_to_strong.eval import eval_model_acc
-from weak_to_strong.model import update_sharded_checkpoint
+from weak_to_strong.model import update_model_incremental
 from train_simple import main as train_simple_main
 import fire
 
@@ -113,10 +113,10 @@ def main(
     if verbose:
         print("Updating model weights")
         print(f"coef_best={coef_best}, best_path={best_path}")
-    update_sharded_checkpoint(model, best_path, coef_best)
+    model.update_state(best_path, coef_best)
     if verbose:
         print(f"coef_final={coef_final}, final_path={final_path}")
-    update_sharded_checkpoint(model, final_path, coef_final)
+    model.update_state(final_path, coef_final)
 
     test_results = eval_model_acc(model, eval_ds, eval_batch_size)
     return float(

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -24,14 +24,16 @@ class TaskVectorModule(torch.nn.Module):
 
 def main(
     task_optim: str = "adam",
-    task_lr: float = 1e-4,
-    task_max_steps: int = 100,
+    task_lr: float = 0.1,
+    task_max_steps: int = 50,
     task_max_steps_wo_improvement: int = 5,
-    task_log_every: int = 10,
+    task_log_every: int = 5,
     task_device: str = "cuda",
     task_dtype: str = "float32",
+    task_seed: int = 0,
     **kwargs
 ):
+    torch.manual_seed(task_seed)
     dtype = getattr(torch, task_dtype)
     config = {}
     config.update(kwargs)

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -64,6 +64,7 @@ def main(
     print(f"coefs dtype: {module.coefs.dtype}")
     print(f"coefs device: {module.coefs.device}")
     trainable_params = list(module.parameters())
+    print(f"trainable_params: {trainable_params}")
     # create optimizer
     if task_optim.lower() == "adam":
         optimizer = torch.optim.Adam(

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -32,7 +32,7 @@ def main(
     task_device: str = "cuda",
     task_dtype: str = "float32",
     task_seed: int = 0,
-    task_lr_schedule: str = "cosine_anneal",
+    task_lr_schedule: str = "linear",
     **kwargs
 ):
     torch.manual_seed(task_seed)
@@ -94,9 +94,15 @@ def main(
         lr_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
             optimizer, task_max_steps
         )
+    elif task_lr_schedule == "linear":
+        lr_scheduler = get_linear_schedule_with_warmup(
+            optimizer, num_warmup_steps=0, num_training_steps=task_max_steps
+        )
     elif task_lr_schedule == "linear_with_warmup":
         lr_scheduler = get_linear_schedule_with_warmup(
-            optimizer, num_warmup_steps=50, num_training_steps=task_max_steps
+            optimizer,
+            num_warmup_steps=int(0.1 * task_max_steps),
+            num_training_steps=task_max_steps,
         )
     else:
         lr_scheduler = torch.optim.lr_scheduler.LambdaLR(

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -1,5 +1,6 @@
 import torch
 import torch_optimizer as toptim
+import wandb
 from evaluate_task_vector import main as evaluate_task_vector_main
 import fire
 
@@ -27,6 +28,30 @@ def main(
     task_device: str = "cuda",
     **kwargs
 ):
+    config = {}
+    config.update(kwargs)
+    config.update({
+        "task_optim": task_optim,
+        "task_lr": task_lr,
+        "task_max_steps": task_max_steps,
+        "task_max_steps_wo_improvement": task_max_steps_wo_improvement,
+        "task_log_every": task_log_every,
+        "task_device": task_device,
+    })
+    wandb_name = (
+        f"{kwargs.get('model_size', 'default').split('/')[-1]}_"
+        f"{kwargs.get('ds_name', 'default')}_"
+        f"{kwargs.get('loss', 'default')}"
+    )
+    wandb.init(
+        project="weak-to-strong",
+        config=config,
+        group=kwargs.get("sweep_subfolder", "default"),
+        job_type="task_vector",
+        name=wandb_name,
+        dir=kwargs.get("results_folder", "/tmp/results"),
+        reinit=True,
+    )
     module = TaskVectorModule(**kwargs).to(task_device)
     assert module.coefs.requires_grad
     trainable_params = list(module.parameters())
@@ -49,6 +74,12 @@ def main(
         assert loss.requires_grad
         if step % task_log_every == 0:
             print(f"step: {step}, loss: {loss.item()}")
+            wandb.log({
+                "loss": loss.item(),
+                "coef_best": module.coefs[0].item(),
+                "coef_final": module.coefs[1].item(),
+                "step": step,
+            })
         if loss < best_loss:
             best_loss = loss
             steps_wo_improvement = 0
@@ -61,6 +92,12 @@ def main(
         optimizer.step()
     print(f"best_loss: {best_loss.item()}")
     print(f"best_coefs: {module.coefs.detach().tolist()}")
+    wandb.log({
+        "best_loss": best_loss.item(),
+        "best_coef_best": module.coefs[0].item(),
+        "best_coef_final": module.coefs[1].item(),
+    })
+    wandb.finish()
 
 
 if __name__ == "__main__":

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -28,6 +28,7 @@ def main(
     **kwargs
 ):
     module = TaskVectorModule(**kwargs).to(task_device)
+    assert module.coefs.requires_grad
     trainable_params = list(module.parameters())
     # create optimizer
     if task_optim.lower() == "adam":
@@ -45,6 +46,7 @@ def main(
     steps_wo_improvement = 0
     for step in range(task_max_steps):
         loss = module()
+        assert loss.requires_grad
         if step % task_log_every == 0:
             print(f"step: {step}, loss: {loss.item()}")
         if loss < best_loss:

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -24,9 +24,10 @@ def main(
     task_max_steps: int = 100,
     task_max_steps_wo_improvement: int = 5,
     task_log_every: int = 10,
+    task_device: str = "cuda",
     **kwargs
 ):
-    module = TaskVectorModule(**kwargs)
+    module = TaskVectorModule(**kwargs).to(task_device)
     trainable_params = list(module.parameters())
     # create optimizer
     if task_optim.lower() == "adam":
@@ -40,7 +41,7 @@ def main(
             f"invalid optimizer {task_optim}, must be adam or adafactor"
         )
     # train
-    best_loss = torch.tensor([1.0])
+    best_loss = torch.tensor([1.0], device=task_device)
     steps_wo_improvement = 0
     for step in range(task_max_steps):
         loss = module()

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -1,0 +1,55 @@
+import torch
+import torch_optimizer as toptim
+from evaluate_task_vector import main as evaluate_task_vector_main
+import fire
+
+
+def main(
+    task_optim: str = "adam",
+    task_lr: float = 1e-4,
+    task_max_steps: int = 100,
+    task_max_steps_wo_improvement: int = 5,
+    task_log_every: int = 10,
+    **kwargs
+):
+    # create params for pair of coefs
+    trainable_params = torch.nn.Parameter(torch.zeros(2))
+    # create optimizer
+    if task_optim.lower() == "adam":
+        optimizer = torch.optim.Adam(
+            trainable_params, lr=task_lr, betas=(0.9, 0.95)
+        )
+    elif task_optim.lower() == "adafactor":
+        optimizer = toptim.Adafactor(trainable_params, lr=task_lr)
+    else:
+        assert False, (
+            f"invalid optimizer {task_optim}, must be adam or adafactor"
+        )
+    # train
+    best_loss = torch.tensor([1.0])
+    steps_wo_improvement = 0
+    for step in range(task_max_steps):
+        acc = evaluate_task_vector_main(
+            coef_best=trainable_params[0],
+            coef_final=trainable_params[1],
+            **kwargs
+        )
+        loss = 1.0 - acc
+        if step % task_log_every == 0:
+            print(f"step: {step}, loss: {loss.item()}")
+        if loss < best_loss:
+            best_loss = loss
+            steps_wo_improvement = 0
+        else:
+            steps_wo_improvement += 1
+        if steps_wo_improvement >= task_max_steps_wo_improvement:
+            break
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+    print(f"best_loss: {best_loss.item()}")
+    print(f"best_coefs: {trainable_params.detach().tolist()}")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -99,7 +99,6 @@ def main(
         optimizer.zero_grad()
         loss.backward()
         assert module.coefs.requires_grad
-        assert module.coefs.grad is not None
         print(f"coef grads: {module.coefs.grad}")
         optimizer.step()
     print(f"best_loss: {best_loss.item()}")

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -11,13 +11,11 @@ class TaskVectorModule(torch.nn.Module):
         self.kwargs = kwargs
 
     def forward(self):
-        acc = evaluate_task_vector_main(
+        return evaluate_task_vector_main(
             coef_best=self.coefs[0],
             coef_final=self.coefs[1],
             **self.kwargs
         )
-        loss = 1.0 - acc
-        return loss
 
 
 def main(

--- a/optim_task_vector.py
+++ b/optim_task_vector.py
@@ -93,8 +93,10 @@ def main(
             break
         optimizer.zero_grad()
         loss.backward()
+        print(f"loss grad: {loss.grad}")
+        assert module.coefs.requires_grad
         assert module.coefs.grad is not None
-        print(f"grads: {module.coefs.grad.tolist()}")
+        print(f"coef grads: {module.coefs.grad.tolist()}")
         optimizer.step()
     print(f"best_loss: {best_loss.item()}")
     print(f"best_coefs: {module.coefs.detach().tolist()}")

--- a/train_simple.py
+++ b/train_simple.py
@@ -72,10 +72,6 @@ def main(
     epochs = w2s_epochs if is_w2s else gt_epochs
     loss = loss if is_w2s else "xent"
 
-    # this is per device!
-    if minibatch_size_per_device is None:
-        minibatch_size_per_device = model_config.minibatch_size_per_device or 1
-
     use_default_lr = False
     if lr is None:
         assert batch_size == 32, (
@@ -254,6 +250,7 @@ def main(
                 )
         except Exception as e:
             raise RuntimeError("Failed to sync results to remote storage.") from e
+    return save_path
 
 
 if __name__ == "__main__":

--- a/train_simple.py
+++ b/train_simple.py
@@ -56,6 +56,7 @@ def main(
     # still do final evals (which requires eval_every to be set to a non-zero, non-None value).
     # Grount-truth fine-tuning does not do any intermediate evals.
     w2s_eval_every: int = 10000000,
+    w2s_log_every: int = 100,
     # If set, this command will be run to sync the results to remote storage
     sync_command: Optional[str] = None,
     skip_if_exists: bool = False,
@@ -70,6 +71,7 @@ def main(
 
     is_w2s = weak_labels_path is not None or weak_model_size is not None
     eval_every = w2s_eval_every if is_w2s else 10000000
+    log_every = w2s_log_every if is_w2s else None
     epochs = w2s_epochs if is_w2s else gt_epochs
     loss = loss if is_w2s else "xent"
 
@@ -226,6 +228,7 @@ def main(
         lr_schedule=lr_schedule,
         optimizer_name=optim,
         eval_every=eval_every,
+        log_every=log_every,
     )
 
     if weak_ds is not None:

--- a/train_simple.py
+++ b/train_simple.py
@@ -210,7 +210,7 @@ def main(
 
     loss_fn = loss_dict[loss]
     print(f"Training model {model_size}")
-    test_results, weak_ds = train_and_save_model(
+    best_test_results, final_best_test_results, weak_ds = train_and_save_model(
         model_config,
         train1_ds,  # this has weak labels iff weak_labels_path is not None
         test_ds,  # this has ground truth labels no matter what
@@ -234,9 +234,12 @@ def main(
     if weak_ds is not None:
         weak_ds.save_to_disk(save_path + "/" + "weak_labels")
 
-    acc = np.mean([x["acc"] for x in test_results])  # type: ignore
-    res_dict = {"accuracy": acc}
-    print("accuracy:", acc)
+    final_acc = np.mean([x["acc"] for x in final_test_results])  # type: ignore
+    res_dict = {"final_accuracy": final_acc}
+    if best_test_results is not None:
+        best_acc = np.mean([x["acc"] for x in best_test_results])  # type: ignore
+        res_dict["best_accuracy"] = best_acc
+    print("accuracy:", final_acc)
 
     with open(os.path.join(save_path, "config.json"), "w") as f:
         json.dump(config, f, indent=2)

--- a/train_simple.py
+++ b/train_simple.py
@@ -58,7 +58,8 @@ def main(
     w2s_eval_every: int = 10000000,
     # If set, this command will be run to sync the results to remote storage
     sync_command: Optional[str] = None,
-):  
+    skip_if_exists: bool = False,
+):
     assert (
         ds_name in VALID_DATASETS
     ), f"Unknown dataset {ds_name} not in {VALID_DATASETS}"
@@ -179,6 +180,9 @@ def main(
         config["weak_model"] = weak_model_config
 
     save_path = os.path.join(results_folder, sweep_subfolder, config_name)
+    if skip_if_exists and os.path.exists(save_path) and os.listdir(save_path):
+        print(f"Skipping {save_path} because it already exists")
+        return save_path
     logger.configure(
         name="{sweep_subfolder}_{config_name}_{datetime_now}",
         save_path=save_path,

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -116,6 +116,13 @@ MODEL_CONFIGS = [
         default_lr=5e-5,
         eval_batch_size=32,
         lora_modules=GPT2_LORA_MODULES,
+        minibatch_size_per_device=1,
+        custom_kwargs={
+            "torch_dtype": torch.bfloat16
+            if torch.cuda.is_bf16_supported()
+            else torch.float32  # we can only do this because we're using LoRA
+        },
+        gradient_checkpointing=True,
     ),
     ModelConfig(
         name="gpt2-large",

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -173,11 +173,6 @@ MODEL_CONFIGS = [
         minibatch_size_per_device=2,  # this needs adjusting for GPU/dataset
         model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
-        custom_kwargs={
-            "torch_dtype": torch.bfloat16  # we can only do this because we're using LoRA
-            if torch.cuda.is_bf16_supported()
-            else torch.float32,
-        },
     ),
     ModelConfig(
         name="EleutherAI/pythia-12b",

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -173,6 +173,11 @@ MODEL_CONFIGS = [
         minibatch_size_per_device=2,  # this needs adjusting for GPU/dataset
         model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
+        custom_kwargs={
+            "torch_dtype": torch.bfloat16
+            if torch.cuda.is_bf16_supported()
+            else torch.float32  # we can only do this because we're using LoRA
+        },
     ),
     ModelConfig(
         name="EleutherAI/pythia-12b",

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -42,9 +42,9 @@ class ModelConfig:
     default_optimizer: str = "adam"
 
     def load_model(
-        self, 
-        batch_size: int, 
-        use_lm_head: bool, 
+        self,
+        batch_size: int,
+        use_lm_head: bool,
         minibatch_size_per_device: Optional[int] = None,
         num_labels: int = 2,
         linear_probe: bool = False,

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -223,7 +223,8 @@ MODEL_CONFIGS = [
     ModelConfig(
         name="Qwen/Qwen-1_8B",
         default_lr=1e-5,
-        eval_batch_size=2,
+        eval_batch_size=32,
+        minibatch_size_per_device=1,
         gradient_checkpointing=True,
         model_parallel=(per_device_ram < 35e9 and torch.cuda.device_count() > 1),
         custom_kwargs={

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -19,11 +19,14 @@ class ModelConfig:
         eval_batch_size: int
             The batch size to use for evaluation.
         minibatch_size_per_device: Optional[int]
-            The minibatch size per device to use for training. If None, the default is 1.
+            The minibatch size per device to use for training. 
+            If None, the default is 1.
         lora_modules: Optional[list[str]]
-            The LoRA modules to use for the model. If None, the default is None.
+            The LoRA modules to use for the model. 
+            If None, the default is None.
         custom_kwargs: Optional[dict]
-            Custom keyword arguments to pass to the model. If None, the default is None.
+            Custom keyword arguments to pass to the model. 
+            If None, the default is None.
         gradient_checkpointing: bool
             Whether to use gradient checkpointing. The default is False.
         model_parallel: bool
@@ -170,6 +173,11 @@ MODEL_CONFIGS = [
         minibatch_size_per_device=2,  # this needs adjusting for GPU/dataset
         model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
+        custom_kwargs={
+            "torch_dtype": torch.bfloat16  # we can only do this because we're using LoRA
+            if torch.cuda.is_bf16_supported()
+            else torch.float32,
+        },
     ),
     ModelConfig(
         name="EleutherAI/pythia-12b",

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -6,11 +6,6 @@ from sklearn.metrics import roc_auc_score
 from weak_to_strong.common import to_batch
 
 
-def unpack(x):
-    assert isinstance(x, torch.Tensor), type(x)
-    return x.detach().float().cpu().numpy().tolist()
-
-
 def eval_model_acc(
     model: nn.Module, ds: datasets.Dataset, eval_batch_size: int = 16
 ) -> datasets.Dataset:
@@ -22,9 +17,10 @@ def eval_model_acc(
     ds (datasets.Dataset): The dataset on which the model is to be evaluated.
 
     Returns:
-    results (list): A list of dictionaries containing the input_ids, ground truth label,
-                    predicted label, accuracy of prediction, logits and soft label for
-                    each example in the dataset.
+    results (list): 
+        A list of dictionaries containing the input_ids, ground truth label,
+        predicted label, accuracy of prediction, logits and soft label for
+        each example in the dataset.
     """
 
     model.eval()
@@ -35,21 +31,20 @@ def eval_model_acc(
         for batch in to_batch(ds, eval_batch_size):
             # pad input_ids to common length
             input_ids = torch.nn.utils.rnn.pad_sequence(
-                [torch.tensor(ex) for ex in batch["input_ids"]], batch_first=True
+                [torch.tensor(ex) for ex in batch["input_ids"]], 
+                batch_first=True
             ).to(model.device if hasattr(model, "device") else "cpu")
             labels = batch["soft_label"]
             # run forward pass
-            raw_logits = model(
+            logits = model(
                 input_ids, choice_input_ids=batch.get("choice_input_ids")
             )
 
-            raw_logprobs = torch.nn.functional.log_softmax(raw_logits, dim=-1)
-            logprobs = unpack(raw_logprobs)
-            probs = unpack(raw_logprobs.exp())
-            logits = unpack(raw_logits)
+            logprobs = torch.nn.functional.log_softmax(logits, dim=-1)
+            probs = logprobs.exp()
 
-            preds = np.argmax(logprobs, axis=-1)
-            labels = np.argmax(labels, axis=-1)
+            preds = torch.argmax(logprobs, dim=-1)
+            labels = torch.argmax(labels, dim=-1)
 
             results.extend(
                 [
@@ -82,8 +77,8 @@ def eval_model_acc(
             np.std(accs) / np.sqrt(len(accs)),
         )
         gt, logprob = (
-            np.array([r["gt_label"] for r in results]),
-            np.array([r["logprob"] for r in results])[:, 1],
+            torch.tensor([r["gt_label"] for r in results]),
+            torch.tensor([r["logprob"] for r in results])[:, 1],
         )
         print("AUC against ground truth:", roc_auc_score(gt, logprob))
 

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -34,11 +34,11 @@ def eval_model_acc(
                 [torch.tensor(ex) for ex in batch["input_ids"]], 
                 batch_first=True
             ).to(model.device if hasattr(model, "device") else "cpu")
-            labels = batch["soft_label"]
             # run forward pass
             logits = model(
                 input_ids, choice_input_ids=batch.get("choice_input_ids")
             )
+            labels = torch.tensor(batch["soft_label"]).to(logits.device)
 
             logprobs = torch.nn.functional.log_softmax(logits, dim=-1)
             probs = logprobs.exp()

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -78,7 +78,7 @@ def eval_model_acc(
         )
         gt, logprob = (
             torch.tensor([r["gt_label"] for r in results]),
-            torch.tensor([r["logprob"] for r in results])[:, 1],
+            torch.tensor([r["logprob"][1] for r in results]),
         )
         print("AUC against ground truth:", roc_auc_score(gt, logprob))
 

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -63,8 +63,8 @@ def eval_model_acc(
             probs = unpack(raw_logprobs.exp())
             logits = unpack(raw_logits)
 
-            preds = torch.argmax(raw_logprobs, dim=-1)
-            labels = torch.argmax(labels, dim=-1)
+            preds = np.argmax(logprobs, axis=-1)
+            labels = np.argmax(labels, axis=-1)
 
             results.extend(
                 [

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -118,10 +118,6 @@ def eval_model_accuracy_loss(
     model.eval()
     io_device = model.device if hasattr(model, "device") else 0
     print("Evaluating model accuracy and loss")
-    print(
-        f"requires_grad={any([p.requires_grad for p in model.parameters()])}"
-    )
-    print(f"train={model.training}")
     print(f"device={io_device}")
     print(f"batch_size={batch_size}")
     print(f"minibatch_size={minibatch_size}")

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -31,7 +31,7 @@ def eval_model_acc(
         for batch in to_batch(ds, eval_batch_size):
             # pad input_ids to common length
             input_ids = torch.nn.utils.rnn.pad_sequence(
-                [torch.tensor(ex) for ex in batch["input_ids"]], 
+                [torch.tensor(ex) for ex in batch["input_ids"]],
                 batch_first=True
             ).to(model.device if hasattr(model, "device") else "cpu")
             # run forward pass
@@ -69,7 +69,7 @@ def eval_model_acc(
                     )
                 ]
             )
-        accs = [r["acc"] for r in results]
+        accs = [r["acc"].detach().cpu().numpy() for r in results]
         print(
             "Accuracy against ground truth:",
             np.mean(accs),

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -114,7 +114,7 @@ def eval_model_accuracy_loss(
     ce_loss (torch.Tensor): The cross-entropy loss of the model on the
         given dataset.
     """
-    clear_mem(verbose=True)
+    clear_mem()
     model.eval()
     io_device = model.device if hasattr(model, "device") else 0
     print("Evaluating model accuracy and loss")

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -145,11 +145,11 @@ def eval_model_accuracy_loss(
             batch_loss = torch.nn.functional.cross_entropy(
                 raw_logits, raw_labels, reduction="mean"
             )
-
-            preds = torch.argmax(raw_logprobs, dim=-1)
-            labels = torch.argmax(raw_labels, dim=-1)
-
-            batch_acc = torch.mean((preds == labels).float())
+            with torch.inference_mode():
+                # Compute accuracy without affecting gradients
+                preds = torch.argmax(raw_logprobs, dim=-1)
+                labels = torch.argmax(raw_labels, dim=-1)
+                batch_acc = torch.mean((preds == labels).float())
             if total_loss is None:
                 total_loss = batch_loss
             else:

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -145,22 +145,22 @@ def eval_model_accuracy_loss(
             batch_loss = torch.nn.functional.cross_entropy(
                 raw_logits, raw_labels, reduction="mean"
             )
+            if total_loss is None:
+                total_loss = batch_loss
+            else:
+                total_loss += batch_loss
             with torch.inference_mode():
                 # Compute accuracy without affecting gradients
                 preds = torch.argmax(raw_logprobs, dim=-1)
                 labels = torch.argmax(raw_labels, dim=-1)
                 batch_acc = torch.mean((preds == labels).float())
-            if total_loss is None:
-                total_loss = batch_loss
-            else:
-                total_loss += batch_loss
-            if total_accuracy is None:
-                total_accuracy = batch_acc
-            else:
-                total_accuracy += batch_acc
+                if total_accuracy is None:
+                    total_accuracy = batch_acc
+                else:
+                    total_accuracy += batch_acc
             n_batches += 1
     assert total_loss is not None
     assert total_accuracy is not None
-    accuracy = total_accuracy / n_batches
+    accuracy = total_accuracy.clone() / n_batches
     ce_loss = total_loss / n_batches
     return accuracy, ce_loss

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -111,7 +111,6 @@ def eval_model_accuracy_loss(
     ce_loss (torch.Tensor): The cross-entropy loss of the model on the
         given dataset.
     """
-    model.requires_grad_(False)
     model.eval()
 
     total_loss = None

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -121,6 +121,9 @@ def eval_model_accuracy_loss(
         f"requires_grad={any([p.requires_grad for p in model.parameters()])}"
     )
     print(f"train={model.training}")
+    print(f"device={io_device}")
+    print(f"batch_size={batch_size}")
+    print(f"minibatch_size={minibatch_size}")
 
     total_loss = None
     total_accuracy = None

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -112,6 +112,11 @@ def eval_model_accuracy_loss(
         given dataset.
     """
     model.eval()
+    print("Evaluating model accuracy and loss")
+    print(
+        f"requires_grad={any([p.requires_grad for p in model.parameters()])}"
+    )
+    print(f"train={model.training}")
 
     total_loss = None
     total_accuracy = None

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -16,7 +16,8 @@ def extract_accuracy(results: datasets.Dataset) -> float:
 
 
 def extract_ce_loss(results: datasets.Dataset) -> torch.Tensor:
-    losses = torch.stack([r["loss"] for r in results])  # type: ignore
+    print("extract_ce_loss", type(results[0]["loss"]))
+    losses = torch.cat([r["loss"] for r in results])  # type: ignore
     return torch.mean(losses, dim=0)
 
 

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -60,6 +60,17 @@ def eval_model_acc(
             losses = torch.nn.functional.cross_entropy(
                 raw_logits, raw_labels, reduction="none"
             )
+            assert isinstance(losses, torch.Tensor), (
+                f"losses is not a tensor: {type(losses)}"
+            )
+            assert losses.ndim == 1, f"losses.ndim: {losses.ndim}"
+            assert losses.shape[0] == raw_labels.shape[0], (
+                f"losses.shape[0]: {losses.shape[0]}, "
+                f"raw_labels.shape[0]: {raw_labels.shape[0]}"
+            )
+            assert isinstance(losses[0], torch.Tensor), (
+                f"losses[0] is not a tensor: {type(losses[0])}"
+            )
             logprobs = unpack(raw_logprobs)
             probs = unpack(raw_logprobs.exp())
             logits = unpack(raw_logits)

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -103,6 +103,9 @@ def eval_model_acc(
                     )
                 ]
             )
+            assert isinstance(results[-1]["loss"], torch.Tensor), (
+                f"results[-1]['loss'] is not a tensor: {type(results[-1]['loss'])}"
+            )
         accs = [r["acc"] for r in results]
         print(
             "Accuracy against ground truth:",
@@ -115,5 +118,12 @@ def eval_model_acc(
             np.array([r["logprob"] for r in results])[:, 1],
         )
         print("AUC against ground truth:", roc_auc_score(gt, logprob))
+
+        assert isinstance(results[0]["loss"], torch.Tensor), (
+            f"results[0]['loss'] is not a tensor: {type(results[-1]['loss'])}"
+        )
+        assert isinstance(results[-1]["loss"], torch.Tensor), (
+            f"results[-1]['loss'] is not a tensor: {type(results[-1]['loss'])}"
+        )
 
         return datasets.Dataset.from_list(results)

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -4,7 +4,7 @@ import numpy as np
 import torch
 from torch import nn
 from sklearn.metrics import roc_auc_score
-from weak_to_strong.common import to_batch
+from weak_to_strong.common import clear_mem, to_batch
 
 
 def unpack(x):
@@ -114,6 +114,7 @@ def eval_model_accuracy_loss(
     ce_loss (torch.Tensor): The cross-entropy loss of the model on the
         given dataset.
     """
+    clear_mem(verbose=True)
     model.eval()
     io_device = model.device if hasattr(model, "device") else 0
     print("Evaluating model accuracy and loss")

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -111,7 +111,7 @@ def eval_model_accuracy_loss(
     ce_loss (torch.Tensor): The cross-entropy loss of the model on the
         given dataset.
     """
-
+    model.requires_grad_(False)
     model.eval()
 
     total_loss = None
@@ -150,6 +150,6 @@ def eval_model_accuracy_loss(
         n_batches += 1
     assert total_loss is not None
     assert total_accuracy is not None
-    total_accuracy /= n_batches
-    total_loss /= n_batches
-    return total_accuracy, total_loss
+    accuracy = total_accuracy / n_batches
+    ce_loss = total_loss / n_batches
+    return accuracy, ce_loss

--- a/weak_to_strong/eval.py
+++ b/weak_to_strong/eval.py
@@ -137,7 +137,7 @@ def eval_model_accuracy_loss(
             input_ids = torch.nn.utils.rnn.pad_sequence(
                 [torch.tensor(ex) for ex in mbatch["input_ids"]],
                 batch_first=True
-            ).to(io_device)
+            ).to(device=io_device)
             # run forward pass
             raw_logits = model(
                 input_ids, choice_input_ids=mbatch.get("choice_input_ids")

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -126,7 +126,7 @@ class TransformerWithHead(PreTrainedModel):
             logits = self.score(hidden_states)
 
         return logits
-    
+
     def update_state(self, path: str, update_coef: float | torch.Tensor = 1.0):
         state_dict = torch.load(path)
         state_dict = {
@@ -135,6 +135,12 @@ class TransformerWithHead(PreTrainedModel):
         }
 
         # directly update model state using update_coef
+        updated = False
         for name, param in self.named_parameters():
+            if not param.requires_grad:
+                continue
             if name in state_dict:
                 param.data.add_((state_dict[name] - param.data) * update_coef)
+                updated = True
+        if not updated:
+            raise ValueError("No parameters updated")

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -123,6 +123,13 @@ class TransformerWithHead(PreTrainedModel):
                     for i in range(len(input_lens))
                 ]
             )
+            assert hidden_states.dtype == self.score.weight.dtype, (
+                f"hidden_states.dtype={hidden_states.dtype}, "
+                f"score.weight.dtype={self.score.weight.dtype}, "
+                f"input_ids.dtype={input_ids.dtype}, "
+                f"hidden_states.device={hidden_states.device}, "
+                f"score.weight.device={self.score.weight.device}"
+            )
             self.score.to(hidden_states.device)
             if self.linear_probe:
                 hidden_states = hidden_states.detach()

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -127,7 +127,7 @@ class TransformerWithHead(PreTrainedModel):
 
         return logits
     
-    def update_state(self, path: str, update_coef: float = 1.0):
+    def update_state(self, path: str, update_coef: float | torch.Tensor = 1.0):
         state_dict = torch.load(path)
         state_dict = {
             k.replace("transformer.module", "transformer"): v

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -178,9 +178,12 @@ class TransformerWithHead(PreTrainedModel):
         updated = False
         for name, state in state_dict.items():
             if "lora" in name or "score" in name:
-                state.to(device=self.device, dtype=self.dtype)
+                state = state.to(device=self.device, dtype=self.dtype)
                 state.requires_grad_(False)
                 orig_param = get_attr(self, name.split("."))
+                orig_param = orig_param.to(
+                    device=self.device, dtype=self.dtype
+                )
                 assert (state != orig_param).any()
                 updated_param = (
                     update_coef * state +

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -161,6 +161,7 @@ class TransformerWithHead(PreTrainedModel):
                     update_coef * state_dict[name] +
                     (1 - update_coef) * param.data
                 )
+                print(f"Updated {name}, requires_grad={param.requires_grad}")
                 updated = True
         if not updated:
             raise ValueError("No parameters updated")

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -162,11 +162,12 @@ class TransformerWithHead(PreTrainedModel):
                     update_coef * state_dict[name] +
                     (1 - update_coef) * param.data
                 )
-                param.data.copy_(updated_weight)
+                self._parameters[name] = torch.nn.Parameter(updated_weight)
                 print(
                     f"Updated {name}, "
+                    f"updated_weight.type={type(updated_weight)}, "
                     f"updated_weight.requires_grad={updated_weight.requires_grad}, "
-                    f"param.requires_grad={param.requires_grad}, "
+                    f"param.requires_grad={self._parameters[name].requires_grad}, "
                 )
                 updated = True
         if not updated:

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -142,9 +142,10 @@ class TransformerWithHead(PreTrainedModel):
         # directly update model state using update_coef
         updated = False
         for name, param in self.named_parameters():
-            if not param.requires_grad:
-                continue
-            if name in state_dict:
+            if param.requires_grad and name in state_dict:
+                state_dict[name].to(
+                    device=param.device, dtype=param.dtype
+                )
                 param.data = (
                     update_coef * state_dict[name] +
                     (1 - update_coef) * param.data

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -140,7 +140,10 @@ class TransformerWithHead(PreTrainedModel):
             if not param.requires_grad:
                 continue
             if name in state_dict:
-                param.data.add_((state_dict[name] - param.data) * update_coef)
+                param.data = (
+                    param.data + 
+                    (state_dict[name] - param.data) * update_coef
+                )
                 updated = True
         if not updated:
             raise ValueError("No parameters updated")

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -133,6 +133,8 @@ class TransformerWithHead(PreTrainedModel):
         return logits
 
     def update_state(self, path: str, update_coef: float | torch.Tensor = 1.0):
+        if not isinstance(update_coef, torch.Tensor):
+            update_coef = torch.tensor(update_coef)
         state_dict = torch.load(path)
         state_dict = {
             k.replace("transformer.module", "transformer"): v
@@ -143,9 +145,8 @@ class TransformerWithHead(PreTrainedModel):
         updated = False
         for name, param in self.named_parameters():
             if param.requires_grad and name in state_dict:
-                state_dict[name].to(
-                    device=param.device, dtype=param.dtype
-                )
+                state_dict[name].to(device=param.device, dtype=param.dtype)
+                update_coef.to(device=param.device, dtype=param.dtype)
                 param.data = (
                     update_coef * state_dict[name] +
                     (1 - update_coef) * param.data

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -5,6 +5,28 @@ from peft import get_peft_model, LoraConfig, TaskType, PeftType  # type: ignore
 from typing import Optional
 
 
+# Recursive attribute access
+def del_attr(obj, names):
+    if len(names) == 1:
+        delattr(obj, names[0])
+    else:
+        del_attr(getattr(obj, names[0]), names[1:])
+
+
+def set_attr(obj, names, val):
+    if len(names) == 1:
+        setattr(obj, names[0], val)
+    else:
+        set_attr(getattr(obj, names[0]), names[1:], val)
+
+
+def get_attr(obj, names):
+    if len(names) == 1:
+        return getattr(obj, names[0])
+    else:
+        return get_attr(getattr(obj, names[0]), names[1:])
+
+
 @dataclass
 class HeadOutput:
     logits: torch.FloatTensor
@@ -158,14 +180,14 @@ class TransformerWithHead(PreTrainedModel):
             if "lora" in name or "score" in name:
                 state.to(device=self.device, dtype=self.dtype)
                 state.requires_grad_(False)
-                orig_param = getattr(self, name)
+                orig_param = get_attr(self, name.split("."))
                 assert (state != orig_param).any()
                 updated_param = (
                     update_coef * state +
                     (1 - update_coef) * orig_param
                 )
-                delattr(self, name)
-                setattr(self, name, updated_param)
+                del_attr(self, name.split("."))
+                set_attr(self, name.split("."), updated_param)
                 print(
                     f"Updated {name}: "
                     f"type={type(updated_param)}, "

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -1,9 +1,114 @@
 from dataclasses import dataclass
-
+from functools import partial
+import gc
+import json
+import os
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM, PreTrainedModel
+from transformers.modeling_utils import (
+    WEIGHTS_INDEX_NAME,
+    SAFE_WEIGHTS_INDEX_NAME,
+    is_safetensors_available,
+    safe_load_file,
+    logger,
+    is_torch_greater_or_equal_than_1_13,
+)
 from peft import get_peft_model, LoraConfig, TaskType, PeftType  # type: ignore
 from typing import Optional
+
+
+def update_sharded_checkpoint(
+    model, folder, update_coef: float = 1.0, strict=True, prefer_safe=True
+):
+    """
+    This is the same as transformers.modeling_utils.update_sharded_checkpoint,
+    but with  the new update_coef parameter, allowing incremental updates to
+    the model weights.
+    See START OF CHANGE below.
+    """
+    # Load the index
+    index_file = os.path.join(folder, WEIGHTS_INDEX_NAME)
+    safe_index_file = os.path.join(folder, SAFE_WEIGHTS_INDEX_NAME)
+
+    index_present = os.path.isfile(index_file)
+    safe_index_present = os.path.isfile(safe_index_file)
+
+    if not index_present and not (
+        safe_index_present and is_safetensors_available()
+    ):
+        filenames = (
+            (WEIGHTS_INDEX_NAME, SAFE_WEIGHTS_INDEX_NAME)
+            if is_safetensors_available() else (WEIGHTS_INDEX_NAME,)
+        )
+        raise ValueError(
+            f"Can't find a checkpoint index ({' or '.join(filenames)})"
+            f" in {folder}."
+        )
+
+    load_safe = False
+    if safe_index_present:
+        if prefer_safe:
+            if is_safetensors_available():
+                load_safe = True  # load safe due to preference
+            else:
+                logger.warning(
+                    f"Cannot load sharded checkpoint at {folder} safely since "
+                    "safetensors is not installed!"
+                )
+        elif not index_present:
+            load_safe = True  # load safe since we have no other choice
+
+    load_index = safe_index_file if load_safe else index_file
+
+    with open(load_index, "r", encoding="utf-8") as f:
+        index = json.load(f)
+
+    shard_files = list(set(index["weight_map"].values()))
+
+    # If strict=True, error before loading any of the state dicts.
+    loaded_keys = index["weight_map"].keys()
+    model_keys = model.state_dict().keys()
+    missing_keys = [key for key in model_keys if key not in loaded_keys]
+    unexpected_keys = [key for key in loaded_keys if key not in model_keys]
+    if strict and (len(missing_keys) > 0 or len(unexpected_keys) > 0):
+        error_message = (
+            f"Error(s) in loading state_dict for {model.__class__.__name__}"
+        )
+        if len(missing_keys) > 0:
+            str_missing_keys = ",".join([f'"{k}"' for k in missing_keys])
+            error_message += f"\nMissing key(s): {str_missing_keys}."
+        if len(unexpected_keys) > 0:
+            str_unexpected_keys = ",".join([f'"{k}"' for k in unexpected_keys])
+            error_message += f"\nMissing key(s): {str_unexpected_keys}."
+        raise RuntimeError(error_message)
+
+    if is_torch_greater_or_equal_than_1_13:
+        weights_only_kwarg = {"weights_only": True}
+    else:
+        weights_only_kwarg = {}
+    loader = safe_load_file if load_safe else partial(
+        torch.load, map_location="cpu", **weights_only_kwarg
+    )
+
+    for shard_file in shard_files:
+        state_dict = loader(os.path.join(folder, shard_file))
+        
+        # START OF CHANGE
+        # Update each weight using the given formula
+        for name, param in model.named_parameters():
+            if name in state_dict:
+                update = update_coef * (state_dict[name] - param.data)
+                param.data.add_(update)
+        # END OF CHANGE
+
+        # Make sure memory is freed before we load the next state dict.
+        del state_dict
+        gc.collect()
+
+    # Return the same thing as PyTorch load_state_dict function.
+    return torch.nn.modules.module._IncompatibleKeys(
+        missing_keys, unexpected_keys
+    )
 
 
 @dataclass

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -191,7 +191,9 @@ class TransformerWithHead(PreTrainedModel):
                 print(
                     f"Updated {name}: "
                     f"type={type(updated_param)}, "
-                    f"requires_grad={updated_param.requires_grad}"
+                    f"requires_grad={updated_param.requires_grad}, "
+                    f"device={updated_param.device}, "
+                    f"dtype={updated_param.dtype}"
                 )
                 updated = True
         if not updated:

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -193,7 +193,10 @@ class TransformerWithHead(PreTrainedModel):
                     f"type={type(updated_param)}, "
                     f"requires_grad={updated_param.requires_grad}, "
                     f"device={updated_param.device}, "
-                    f"dtype={updated_param.dtype}"
+                    f"dtype={updated_param.dtype}, "
+                    f"self.dtype={self.dtype}, "
+                    f"state.dtype={state.dtype}, "
+                    f"orig_param.dtype={orig_param.dtype}, "
                 )
                 updated = True
         if not updated:

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -60,6 +60,9 @@ class TransformerWithHead(PreTrainedModel):
                 lm_head.weight.dtype
             )
             torch.nn.init.normal_(self.score.weight, std=0.0)
+            print("Initialized linear head to zeros")
+            print(f"lm_head.weight.dtype={lm_head.weight.dtype}")
+            print(f"score.weight.dtype={self.score.weight.dtype}")
         self.linear_probe = linear_probe
 
     @property

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -133,8 +133,10 @@ class TransformerWithHead(PreTrainedModel):
         return logits
 
     def update_state(self, path: str, update_coef: float | torch.Tensor = 1.0):
+        print(f"update_coef={update_coef}")
         if not isinstance(update_coef, torch.Tensor):
             update_coef = torch.tensor(update_coef)
+        print(f"requires_grad={update_coef.requires_grad}")
         state_dict = torch.load(path)
         state_dict = {
             k.replace("transformer.module", "transformer"): v
@@ -147,6 +149,7 @@ class TransformerWithHead(PreTrainedModel):
             if param.requires_grad and name in state_dict:
                 state_dict[name].to(device=param.device, dtype=param.dtype)
                 update_coef.to(device=param.device, dtype=param.dtype)
+                assert state_dict[name] != param.data
                 param.data = (
                     update_coef * state_dict[name] +
                     (1 - update_coef) * param.data

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -123,14 +123,9 @@ class TransformerWithHead(PreTrainedModel):
                     for i in range(len(input_lens))
                 ]
             )
-            assert hidden_states.dtype == self.score.weight.dtype, (
-                f"hidden_states.dtype={hidden_states.dtype}, "
-                f"score.weight.dtype={self.score.weight.dtype}, "
-                f"input_ids.dtype={input_ids.dtype}, "
-                f"hidden_states.device={hidden_states.device}, "
-                f"score.weight.device={self.score.weight.device}"
+            self.score.to(
+                device=hidden_states.device, dtype=hidden_states.dtype
             )
-            self.score.to(hidden_states.device)
             if self.linear_probe:
                 hidden_states = hidden_states.detach()
             logits = self.score(hidden_states)

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -151,8 +151,7 @@ class TransformerWithHead(PreTrainedModel):
         # directly update model state using update_coef
         updated = False
         for name, param in self.named_parameters():
-            is_lora = any([lora in name for lora in self.lora_modules])
-            if is_lora and name in state_dict:
+            if "lora" in name and name in state_dict:
                 state_dict[name].to(device=param.device, dtype=param.dtype)
                 update_coef.to(device=param.device, dtype=param.dtype)
                 state_dict[name].requires_grad_(False)

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -141,8 +141,8 @@ class TransformerWithHead(PreTrainedModel):
                 continue
             if name in state_dict:
                 param.data = (
-                    param.data + 
-                    (state_dict[name] - param.data) * update_coef
+                    update_coef * state_dict[name] +
+                    (1 - update_coef) * param.data
                 )
                 updated = True
         if not updated:

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -149,7 +149,7 @@ class TransformerWithHead(PreTrainedModel):
             if param.requires_grad and name in state_dict:
                 state_dict[name].to(device=param.device, dtype=param.dtype)
                 update_coef.to(device=param.device, dtype=param.dtype)
-                assert state_dict[name] != param.data
+                assert (state_dict[name] != param.data).any()
                 param.data = (
                     update_coef * state_dict[name] +
                     (1 - update_coef) * param.data

--- a/weak_to_strong/model.py
+++ b/weak_to_strong/model.py
@@ -164,10 +164,6 @@ class TransformerWithHead(PreTrainedModel):
         if not isinstance(update_coef, torch.Tensor):
             update_coef = torch.tensor(update_coef)
         update_coef.to(device=self.device, dtype=self.dtype)
-        print(f"coef requires_grad={update_coef.requires_grad}")
-        print(f"coef device={update_coef.device}")
-        print(f"coef dtype={update_coef.dtype}")
-        print(f"pre-model requires_grad={self.requires_grad}")
         state_dict = torch.load(path)
         state_dict = {
             k.replace("transformer.module", "transformer"): v
@@ -191,17 +187,6 @@ class TransformerWithHead(PreTrainedModel):
                 )
                 del_attr(self, name.split("."))
                 set_attr(self, name.split("."), updated_param)
-                print(
-                    f"Updated {name}: "
-                    f"type={type(updated_param)}, "
-                    f"requires_grad={updated_param.requires_grad}, "
-                    f"device={updated_param.device}, "
-                    f"dtype={updated_param.dtype}, "
-                    f"self.dtype={self.dtype}, "
-                    f"state.dtype={state.dtype}, "
-                    f"orig_param.dtype={orig_param.dtype}, "
-                )
                 updated = True
         if not updated:
             raise ValueError("No parameters updated")
-        print(f"post-model requires_grad={self.requires_grad}")

--- a/weak_to_strong/train.py
+++ b/weak_to_strong/train.py
@@ -101,7 +101,7 @@ def train_model(
     accuracies = []
     aurocs = []
     eval_acc_dict = {}
-    max_acc = 0
+    max_acc = 0.0
 
     # If the model is wrapped by DataParallel, it doesn't have a device. In this case,
     # we use GPU 0 as the output device. This sadly means that this device will store
@@ -124,10 +124,11 @@ def train_model(
                     ).gradient_checkpointing_enable()
                 if train_with_dropout:
                     model.train()
-                eval_acc = np.mean([r["acc"] for r in eval_results])  # type: ignore
+                eval_acc = float(
+                    np.mean([r["acc"] for r in eval_results])  # type: ignore
+                )
                 eval_acc_dict[step] = eval_acc
-                max_acc = max(max_acc, eval_acc)
-                if eval_acc == max_acc and save_path:
+                if eval_acc > max_acc and save_path:
                     save(
                         model,
                         save_path,
@@ -135,6 +136,7 @@ def train_model(
                         optimizer,
                         lr_scheduler
                     )
+                max_acc = max(max_acc, eval_acc)
                 logger.logkv("eval_accuracy", eval_acc)
                 wandb.log({"eval/accuracy": eval_acc})
             all_logits = []


### PR DESCRIPTION
![image](https://github.com/openai/weak-to-strong/assets/67026888/2b84afd3-ebee-4e29-a292-d0ee45627b05)

It takes 30gb to run for strong=gpt2-medium/weak=gpt2-small, dtype=bfloat16, so any suggestions to reduce memory usage would be greatly appreciated.

The strange way that parameters are updated is taken from https://discuss.pytorch.org/t/how-does-one-have-the-parameters-of-a-model-not-be-leafs/70076/9?u=pinocchio Every other way that I painstakingly tested today just messes up the computational graph.