### PR TITLE
Simplify model configs

### DIFF
--- a/configs/models.yaml
+++ b/configs/models.yaml
@@ -21,6 +21,7 @@ models:
     memory: 5.5e8
     default_lr: 5e-5
     lora_modules: *gpt2_modules
+    torch_dtype: torch.float32
 
   - name: gpt2-medium
     memory: 1.5e9
@@ -61,23 +62,17 @@ models:
     memory: 2.4e10
     minibatch_size_per_device: 2
     lora_modules: *gpt_neox_modules
-    custom_kwargs:
-      torch_dtype: torch.bfloat16
 
   - name: mistralai/Mistral-7B-v0.1
     memory: 1.5e10
     eval_batch_size: 2
     lora_modules: *mistralai_modules
-    custom_kwargs:
-      torch_dtype: torch.bfloat16
 
   - name: Qwen/Qwen-1_8B
     memory: 3.67e9
     eval_batch_size: 2
     custom_kwargs:
       trust_remote_code: true
-      bf16: True
-      fp32: False
       revision: 5fde88dff770a7d036847211f5d9d9705f0caa69
 
   - name: Qwen/Qwen-7B
@@ -85,8 +80,6 @@ models:
     eval_batch_size: 2
     custom_kwargs:
       trust_remote_code: true
-      bf16: True
-      fp32: False
       revision: d4efd21e866b9cb3466cb65b963933f5e98016d1
 
   - name: Qwen/Qwen-14B
@@ -94,6 +87,4 @@ models:
     eval_batch_size: 2
     custom_kwargs:
       trust_remote_code: true
-      bf16: True
-      fp32: False
       revision: 8be2854218fea9054331e217fd26a06f3fd02004

--- a/configs/models.yaml
+++ b/configs/models.yaml
@@ -1,0 +1,99 @@
+lora_modules:
+  gpt_neox: &gpt_neox_modules
+    - dense_h_to_4h
+    - dense_4h_to_h
+    - query_key_value
+  gpt2: &gpt2_modules
+    - c_fc
+    - c_proj
+    - c_attn
+  mistralai: &mistralai_modules
+    - up_proj
+    - down_proj
+    - gate_proj
+    - k_proj
+    - q_proj
+    - v_proj
+
+# NOTE learning rates are not particularly tuned, work somewhat reasonably at train batch size 32
+models:
+  - name: gpt2
+    memory: 5.5e8
+    default_lr: 5e-5
+    lora_modules: *gpt2_modules
+
+  - name: gpt2-medium
+    memory: 1.5e9
+    default_lr: 5e-5
+    lora_modules: *gpt2_modules
+
+  - name: gpt2-large
+    memory: 3.25e9
+    lora_modules: *gpt2_modules
+
+  - name: gpt2-xl
+    memory: 6.43e9
+    eval_batch_size: 2
+    lora_modules: *gpt2_modules
+
+  - name: EleutherAI/pythia-14m
+    memory: 5.3e7
+    lora_modules: *gpt_neox_modules
+
+  - name: EleutherAI/pythia-70m
+    memory: 1.66e8
+    lora_modules: *gpt_neox_modules
+
+  - name: EleutherAI/pythia-160m-v0
+    memory: 3.75e8
+    lora_modules: *gpt_neox_modules
+
+  - name: EleutherAI/pythia-410m
+    memory: 9.11e8
+    lora_modules: *gpt_neox_modules
+
+  - name: EleutherAI/pythia-2.8b
+    memory: 5.68e9
+    minibatch_size_per_device: 2
+    lora_modules: *gpt_neox_modules
+
+  - name: EleutherAI/pythia-12b
+    memory: 2.4e10
+    minibatch_size_per_device: 2
+    lora_modules: *gpt_neox_modules
+    custom_kwargs:
+      torch_dtype: torch.bfloat16
+
+  - name: mistralai/Mistral-7B-v0.1
+    memory: 1.5e10
+    eval_batch_size: 2
+    lora_modules: *mistralai_modules
+    custom_kwargs:
+      torch_dtype: torch.bfloat16
+
+  - name: Qwen/Qwen-1_8B
+    memory: 3.67e9
+    eval_batch_size: 2
+    custom_kwargs:
+      trust_remote_code: true
+      bf16: True
+      fp32: False
+      revision: 5fde88dff770a7d036847211f5d9d9705f0caa69
+
+  - name: Qwen/Qwen-7B
+    memory: 1.6e10
+    eval_batch_size: 2
+    custom_kwargs:
+      trust_remote_code: true
+      bf16: True
+      fp32: False
+      revision: d4efd21e866b9cb3466cb65b963933f5e98016d1
+
+  - name: Qwen/Qwen-14B
+    memory: 3e10
+    eval_batch_size: 2
+    custom_kwargs:
+      trust_remote_code: true
+      bf16: True
+      fp32: False
+      revision: 8be2854218fea9054331e217fd26a06f3fd02004

--- a/train_simple.py
+++ b/train_simple.py
@@ -23,7 +23,7 @@ from weak_to_strong.train import train_and_save_model
 def main(
     # training batch size (number of examples per update)
     batch_size: int = 32,
-    max_ctx: Optional[int] = None,
+    max_ctx: int = 1024,
     ds_name: str = "sciq",
     loss: str = "kl",
     # number of documents
@@ -75,9 +75,6 @@ def main(
     # this is per device!
     if minibatch_size_per_device is None:
         minibatch_size_per_device = model_config.minibatch_size_per_device
-
-    if max_ctx is None:
-        max_ctx = model_config.max_ctx
 
     use_default_lr = False
     if lr is None:

--- a/train_simple.py
+++ b/train_simple.py
@@ -72,6 +72,10 @@ def main(
     epochs = w2s_epochs if is_w2s else gt_epochs
     loss = loss if is_w2s else "xent"
 
+    # this is per device!
+    if minibatch_size_per_device is None:
+        minibatch_size_per_device = model_config.minibatch_size_per_device
+
     use_default_lr = False
     if lr is None:
         assert batch_size == 32, (

--- a/train_simple.py
+++ b/train_simple.py
@@ -72,10 +72,6 @@ def main(
     epochs = w2s_epochs if is_w2s else gt_epochs
     loss = loss if is_w2s else "xent"
 
-    # this is per device!
-    if minibatch_size_per_device is None:
-        minibatch_size_per_device = model_config.minibatch_size_per_device or 1
-
     use_default_lr = False
     if lr is None:
         assert batch_size == 32, (

--- a/train_simple.py
+++ b/train_simple.py
@@ -23,7 +23,7 @@ from weak_to_strong.train import train_and_save_model
 def main(
     # training batch size (number of examples per update)
     batch_size: int = 32,
-    max_ctx: int = 1024,
+    max_ctx: Optional[int] = None,
     ds_name: str = "sciq",
     loss: str = "kl",
     # number of documents
@@ -75,6 +75,9 @@ def main(
     # this is per device!
     if minibatch_size_per_device is None:
         minibatch_size_per_device = model_config.minibatch_size_per_device
+
+    if max_ctx is None:
+        max_ctx = model_config.max_ctx
 
     use_default_lr = False
     if lr is None:

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -5,100 +5,103 @@ from typing import Optional
 from weak_to_strong.loss import logconf_loss_fn, product_loss_fn, xent_loss, kl_loss
 
 
-@dataclass
 class ModelConfig:
-    name: str
-    default_lr: float
-    eval_batch_size: int
-    minibatch_size_per_device: Optional[int] = None
-    lora_modules: Optional[list[str]] = None
-    custom_kwargs: Optional[dict] = None
-    gradient_checkpointing: bool = False
-    model_parallel: bool = False
-    default_optimizer: str = "adam"
+
+    def __init__(
+        self, 
+        name: str, 
+        memory: float,
+        default_lr: float = 1e-5,
+        eval_batch_size: int = 32,
+        minibatch_size_per_device: Optional[int] = None,
+        lora_modules: Optional[list[str]] = None,
+        custom_kwargs: Optional[dict] = None,
+        gradient_checkpointing: bool = False,
+        model_parallel: Optional[bool] = None,
+        default_optimizer: str = "adam",
+    ):
+        self.per_device_ram = torch.cuda.get_device_properties(0).total_memory
+        self.n_devices = torch.cuda.device_count()
+        if model_parallel is None:
+            model_parallel = (
+                self.n_devices > 1 and self.per_device_ram < 2 * self.memory
+            )
+        self.name = name
+        self.memory = memory
+        self.default_lr = default_lr
+        self.eval_batch_size = eval_batch_size
+        self.minibatch_size_per_device = minibatch_size_per_device
+        self.lora_modules = lora_modules
+        self.custom_kwargs = custom_kwargs
+        self.gradient_checkpointing = gradient_checkpointing
+        self.model_parallel = model_parallel
+        self.default_optimizer = default_optimizer
 
 
 GPT_NEOX_LORA_MODULES = ["dense_h_to_4h", "dense_4h_to_h", "query_key_value"]
 GPT2_LORA_MODULES = ["c_fc", "c_proj", "c_attn"]
-per_device_ram = torch.cuda.get_device_properties(0).total_memory
+
 
 # NOTE learning rates are not particularly tuned, work somewhat reasonably at train batch size 32
 MODEL_CONFIGS = [
     ModelConfig(
         name="gpt2",
+        memory=550e6,
         default_lr=5e-5,
-        eval_batch_size=32,
         lora_modules=GPT2_LORA_MODULES,
     ),
     ModelConfig(
         name="gpt2-medium",
+        memory=1.5e9,
         default_lr=5e-5,
-        eval_batch_size=32,
         lora_modules=GPT2_LORA_MODULES,
     ),
     ModelConfig(
         name="gpt2-large",
-        default_lr=1e-5,
-        eval_batch_size=32,
+        memory=3.25e6,
         lora_modules=GPT2_LORA_MODULES,
     ),
     ModelConfig(
         name="gpt2-xl",
-        default_lr=1e-5,
+        memory=6.43e9,
         eval_batch_size=2,
         gradient_checkpointing=True,
         lora_modules=GPT2_LORA_MODULES,
-        # Should use model_parallel on V100s (note: ironically if you have a single V100
-        # it should run, but if you have multiple it won't run without model_parallel
-        # because of the overhead of data parallel training).
-        model_parallel=(per_device_ram < 35e9 and torch.cuda.device_count() > 1),
     ),
     ModelConfig(
         name="EleutherAI/pythia-70m",
-        default_lr=1e-5,
-        eval_batch_size=32,
+        memory=166e6,
         minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
     ),
     ModelConfig(
         name="EleutherAI/pythia-14m",
-        default_lr=1e-5,
-        eval_batch_size=32,
+        memory=53e6,
         minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
     ),
     ModelConfig(
         name="EleutherAI/pythia-160m-v0",
-        default_lr=1e-5,
-        eval_batch_size=32,
+        memory=375e6,
         minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
     ),
     ModelConfig(
         name="EleutherAI/pythia-410m",
-        default_lr=1e-5,
-        eval_batch_size=32,
+        memory=911e6,
         minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
     ),
     ModelConfig(
         name="EleutherAI/pythia-2.8b",
-        default_lr=1e-5,
-        eval_batch_size=32,
+        memory=5.68e9,
         minibatch_size_per_device=2,  # this needs adjusting for GPU/dataset
-        model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
     ),
     ModelConfig(
         name="EleutherAI/pythia-12b",
-        default_lr=1e-5,
-        eval_batch_size=32,
+        memory=24e9,
         minibatch_size_per_device=2,  # this needs adjusting for GPU/dataset
-        model_parallel=False,
         lora_modules=GPT_NEOX_LORA_MODULES,
         custom_kwargs={
             "torch_dtype": torch.bfloat16
@@ -108,7 +111,7 @@ MODEL_CONFIGS = [
     ),
     ModelConfig(
         name="mistralai/Mistral-7B-v0.1",
-        default_lr=1e-5,
+        memory=15e9,
         eval_batch_size=2,
         lora_modules=[
             "up_proj",
@@ -120,7 +123,6 @@ MODEL_CONFIGS = [
         ],
         minibatch_size_per_device=1,  # this needs adjusting for GPU/dataset
         gradient_checkpointing=True,
-        model_parallel=False,
         custom_kwargs={
             "torch_dtype": torch.bfloat16  # we can only do this because we're using LoRA
             if torch.cuda.is_bf16_supported()
@@ -129,10 +131,9 @@ MODEL_CONFIGS = [
     ),
     ModelConfig(
         name="Qwen/Qwen-1_8B",
-        default_lr=1e-5,
+        memory=3.67e9,
         eval_batch_size=2,
         gradient_checkpointing=True,
-        model_parallel=(per_device_ram < 35e9 and torch.cuda.device_count() > 1),
         custom_kwargs={
             "trust_remote_code": True,
             "bf16": torch.cuda.is_bf16_supported(),
@@ -142,10 +143,9 @@ MODEL_CONFIGS = [
     ),
     ModelConfig(
         name="Qwen/Qwen-7B",
-        default_lr=1e-5,
+        memory=16e9,
         eval_batch_size=2,
         gradient_checkpointing=True,
-        model_parallel=True,
         # note: you will probably not be able to run this without many gpus
         custom_kwargs={
             "trust_remote_code": True,
@@ -156,10 +156,9 @@ MODEL_CONFIGS = [
     ),
     ModelConfig(
         name="Qwen/Qwen-14B",
-        default_lr=1e-5,
+        memory=30e9,
         eval_batch_size=2,
         gradient_checkpointing=True,
-        model_parallel=True,
         # note: you will probably not be able to run this bf16 support and without many gpus
         custom_kwargs={
             "trust_remote_code": True,
@@ -170,10 +169,9 @@ MODEL_CONFIGS = [
     ),
     ModelConfig(
         name="Qwen/Qwen-72B",
-        default_lr=1e-5,
+        memory=164e9,
         eval_batch_size=1,
         gradient_checkpointing=True,
-        model_parallel=True,
         # note: you will probably not be able to run this without bf16 support and many gpus
         custom_kwargs={
             "trust_remote_code": True,

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -82,7 +82,7 @@ class ModelConfig:
         n_devices = torch.cuda.device_count()
         if model_parallel is None:
             model_parallel = (
-                n_devices > 1 and 
+                n_devices > 1 and
                 per_device_ram < self.MODEL_PARALLEL_FACTOR * memory
             )
         if gradient_checkpointing is None:

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -55,8 +55,6 @@ class ModelConfig:
             then it uses data parallelism.
         default_optimizer (str, optional):
             The default optimizer. Defaults to "adam".
-        max_ctx (int, optional):
-            The maximum context length. Defaults to 512.
         torch_dtype (str, optional):
             The torch data type. Defaults to None.
             If None and not set in custom_kwargs, then it defaults to
@@ -75,7 +73,6 @@ class ModelConfig:
     gradient_checkpointing: bool
     model_parallel: bool
     default_optimizer: str
-    max_ctx: int
     torch_dtype: str
 
     def __init__(
@@ -90,7 +87,6 @@ class ModelConfig:
         gradient_checkpointing: Optional[bool] = None,
         model_parallel: Optional[bool] = None,
         default_optimizer: str = "adam",
-        max_ctx: int = 512,
         torch_dtype: Optional[str] = None,
     ):
         custom_kwargs = custom_kwargs or {}
@@ -124,8 +120,7 @@ class ModelConfig:
         self.gradient_checkpointing = gradient_checkpointing
         self.model_parallel = model_parallel
         self.default_optimizer = default_optimizer
-        self.max_ctx = max_ctx
-        self.torch_dtype = torch_dtype
+        self.torch_dtype = torch_dtype  # type: ignore
 
 
 MODELS_DICT: dict[str, ModelConfig] = {

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -26,6 +26,31 @@ def load_config(config_path='configs/default.yaml'):
 
 
 class ModelConfig:
+    """
+    Configuration class for the model.
+
+    Args:
+        name (str): The name of the model.
+        memory (float): 
+            The memory required for the model in bytes.
+        default_lr (float, optional):
+            The default learning rate. Defaults to 1e-5.
+        eval_batch_size (int, optional):
+            The batch size for evaluation. Defaults to 32.
+        minibatch_size_per_device (int, optional):
+            The minibatch size per device. Defaults to None.
+        lora_modules (list[str], optional):
+            The list of LORA modules. Defaults to None.
+        custom_kwargs (dict, optional):
+            Custom keyword arguments. Defaults to None.
+        gradient_checkpointing (bool, optional):
+            Whether to use gradient checkpointing. Defaults to None.
+        model_parallel (bool, optional):
+            Whether to use model parallelism. Defaults to None.
+        default_optimizer (str, optional):
+            The default optimizer. Defaults to "adam".
+    """
+
     CHECKPOINTING_MEMORY = 3e9
     MODEL_PARALLEL_FACTOR = 2
     name: str

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -1,31 +1,76 @@
 import torch
-from dataclasses import dataclass
 from typing import Optional
+
+import yaml
 
 from weak_to_strong.loss import logconf_loss_fn, product_loss_fn, xent_loss, kl_loss
 
 
+def load_config(config_path='configs/default.yaml'):
+    """
+    Load the YAML configuration file.
+
+    Parameters:
+    - config_path (str): Path to the YAML configuration file.
+
+    Returns:
+    - dict: Configuration settings.
+    """
+    try:
+        with open(config_path, 'r') as file:
+            config = yaml.safe_load(file)
+        return config
+    except Exception as e:
+        print(f"Error loading the config file {config_path}: {e}")
+        return {}
+
+
 class ModelConfig:
+    CHECKPOINTING_MEMORY = 3e9
+    MODEL_PARALLEL_FACTOR = 2
+    name: str
+    memory: float
+    default_lr: float
+    eval_batch_size: int
+    minibatch_size_per_device: int
+    lora_modules: Optional[list[str]]
+    custom_kwargs: dict
+    gradient_checkpointing: bool
+    model_parallel: bool
+    default_optimizer: str
 
     def __init__(
-        self, 
-        name: str, 
+        self,
+        name: str,
         memory: float,
         default_lr: float = 1e-5,
         eval_batch_size: int = 32,
         minibatch_size_per_device: Optional[int] = None,
         lora_modules: Optional[list[str]] = None,
         custom_kwargs: Optional[dict] = None,
-        gradient_checkpointing: bool = False,
+        gradient_checkpointing: Optional[bool] = None,
         model_parallel: Optional[bool] = None,
         default_optimizer: str = "adam",
     ):
-        self.per_device_ram = torch.cuda.get_device_properties(0).total_memory
-        self.n_devices = torch.cuda.device_count()
+        custom_kwargs = custom_kwargs or {}
+        per_device_ram = torch.cuda.get_device_properties(0).total_memory
+        n_devices = torch.cuda.device_count()
         if model_parallel is None:
             model_parallel = (
-                self.n_devices > 1 and self.per_device_ram < 2 * self.memory
+                n_devices > 1 and 
+                per_device_ram < self.MODEL_PARALLEL_FACTOR * memory
             )
+        if gradient_checkpointing is None:
+            gradient_checkpointing = memory > self.CHECKPOINTING_MEMORY
+        if minibatch_size_per_device is None:
+            minibatch_size_per_device = eval_batch_size
+        if not torch.cuda.is_bf16_supported() and (
+            custom_kwargs.get("torch_dtype") == "torch.bfloat16"
+        ):
+            custom_kwargs["torch_dtype"] = "torch.float32"
+        if not torch.cuda.is_bf16_supported() and custom_kwargs.get("bf16"):
+            custom_kwargs["bf16"] = False
+            custom_kwargs["fp32"] = True
         self.name = name
         self.memory = memory
         self.default_lr = default_lr
@@ -38,154 +83,9 @@ class ModelConfig:
         self.default_optimizer = default_optimizer
 
 
-GPT_NEOX_LORA_MODULES = ["dense_h_to_4h", "dense_4h_to_h", "query_key_value"]
-GPT2_LORA_MODULES = ["c_fc", "c_proj", "c_attn"]
-
-
-# NOTE learning rates are not particularly tuned, work somewhat reasonably at train batch size 32
-MODEL_CONFIGS = [
-    ModelConfig(
-        name="gpt2",
-        memory=550e6,
-        default_lr=5e-5,
-        lora_modules=GPT2_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="gpt2-medium",
-        memory=1.5e9,
-        default_lr=5e-5,
-        lora_modules=GPT2_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="gpt2-large",
-        memory=3.25e6,
-        lora_modules=GPT2_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="gpt2-xl",
-        memory=6.43e9,
-        eval_batch_size=2,
-        gradient_checkpointing=True,
-        lora_modules=GPT2_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="EleutherAI/pythia-70m",
-        memory=166e6,
-        minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        lora_modules=GPT_NEOX_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="EleutherAI/pythia-14m",
-        memory=53e6,
-        minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        lora_modules=GPT_NEOX_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="EleutherAI/pythia-160m-v0",
-        memory=375e6,
-        minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        lora_modules=GPT_NEOX_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="EleutherAI/pythia-410m",
-        memory=911e6,
-        minibatch_size_per_device=32,  # this needs adjusting for GPU/dataset
-        lora_modules=GPT_NEOX_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="EleutherAI/pythia-2.8b",
-        memory=5.68e9,
-        minibatch_size_per_device=2,  # this needs adjusting for GPU/dataset
-        lora_modules=GPT_NEOX_LORA_MODULES,
-    ),
-    ModelConfig(
-        name="EleutherAI/pythia-12b",
-        memory=24e9,
-        minibatch_size_per_device=2,  # this needs adjusting for GPU/dataset
-        lora_modules=GPT_NEOX_LORA_MODULES,
-        custom_kwargs={
-            "torch_dtype": torch.bfloat16
-            if torch.cuda.is_bf16_supported()
-            else torch.float32  # we can only do this because we're using LoRA
-        },
-    ),
-    ModelConfig(
-        name="mistralai/Mistral-7B-v0.1",
-        memory=15e9,
-        eval_batch_size=2,
-        lora_modules=[
-            "up_proj",
-            "down_proj",
-            "gate_proj",
-            "k_proj",
-            "q_proj",
-            "v_proj",
-        ],
-        minibatch_size_per_device=1,  # this needs adjusting for GPU/dataset
-        gradient_checkpointing=True,
-        custom_kwargs={
-            "torch_dtype": torch.bfloat16  # we can only do this because we're using LoRA
-            if torch.cuda.is_bf16_supported()
-            else torch.float32,
-        },
-    ),
-    ModelConfig(
-        name="Qwen/Qwen-1_8B",
-        memory=3.67e9,
-        eval_batch_size=2,
-        gradient_checkpointing=True,
-        custom_kwargs={
-            "trust_remote_code": True,
-            "bf16": torch.cuda.is_bf16_supported(),
-            "fp32": not torch.cuda.is_bf16_supported(),
-            "revision": "5fde88dff770a7d036847211f5d9d9705f0caa69",
-        },
-    ),
-    ModelConfig(
-        name="Qwen/Qwen-7B",
-        memory=16e9,
-        eval_batch_size=2,
-        gradient_checkpointing=True,
-        # note: you will probably not be able to run this without many gpus
-        custom_kwargs={
-            "trust_remote_code": True,
-            "bf16": torch.cuda.is_bf16_supported(),
-            "fp32": not torch.cuda.is_bf16_supported(),
-            "revision": "d4efd21e866b9cb3466cb65b963933f5e98016d1",
-        },
-    ),
-    ModelConfig(
-        name="Qwen/Qwen-14B",
-        memory=30e9,
-        eval_batch_size=2,
-        gradient_checkpointing=True,
-        # note: you will probably not be able to run this bf16 support and without many gpus
-        custom_kwargs={
-            "trust_remote_code": True,
-            "bf16": torch.cuda.is_bf16_supported(),
-            "fp32": not torch.cuda.is_bf16_supported(),
-            "revision": "8be2854218fea9054331e217fd26a06f3fd02004",
-        },
-    ),
-    ModelConfig(
-        name="Qwen/Qwen-72B",
-        memory=164e9,
-        eval_batch_size=1,
-        gradient_checkpointing=True,
-        # note: you will probably not be able to run this without bf16 support and many gpus
-        custom_kwargs={
-            "trust_remote_code": True,
-            "bf16": torch.cuda.is_bf16_supported(),
-            "fp32": not torch.cuda.is_bf16_supported(),
-            "revision": "fec78c0e3b3b10dd9f0ce775c34a686a3255a7d1",
-        },
-        # This model is really big, save space by using adafactor.
-        # Note that even then it will take up ~60GB per GPU on an 8-GPU machine.
-        default_optimizer="adafactor",
-    ),
-]
 MODELS_DICT: dict[str, ModelConfig] = {
-    model_config.name: model_config for model_config in MODEL_CONFIGS
+    cfg["name"]: ModelConfig(**cfg)
+    for cfg in load_config("configs/models.yaml")["models"]
 }
 
 

--- a/weak_to_strong/config.py
+++ b/weak_to_strong/config.py
@@ -31,7 +31,7 @@ class ModelConfig:
 
     Args:
         name (str): The name of the model.
-        memory (float): 
+        memory (float):
             The memory required for the model in bytes.
         default_lr (float, optional):
             The default learning rate. Defaults to 1e-5.
@@ -41,14 +41,22 @@ class ModelConfig:
             The minibatch size per device. Defaults to None.
         lora_modules (list[str], optional):
             The list of LORA modules. Defaults to None.
+            If None, then LORA is not used.
         custom_kwargs (dict, optional):
-            Custom keyword arguments. Defaults to None.
+            Arguments to pass to HF's from_pretrained(). Defaults to None.
         gradient_checkpointing (bool, optional):
             Whether to use gradient checkpointing. Defaults to None.
         model_parallel (bool, optional):
-            Whether to use model parallelism. Defaults to None.
+            Whether to use model parallelism.
+            Defaults to true if the memory requirement exceeds a threshold and
+            there are multiple GPUs available.
+            Model parallelism uses accelerate's automatic model sharding,
+            while if model-parallel is false and you're using multiple GPUs,
+            then it uses data parallelism.
         default_optimizer (str, optional):
             The default optimizer. Defaults to "adam".
+        max_ctx (int, optional):
+            The maximum context length. Defaults to 512.
     """
 
     CHECKPOINTING_MEMORY = 3e9
@@ -63,6 +71,7 @@ class ModelConfig:
     gradient_checkpointing: bool
     model_parallel: bool
     default_optimizer: str
+    max_ctx: int
 
     def __init__(
         self,
@@ -76,6 +85,7 @@ class ModelConfig:
         gradient_checkpointing: Optional[bool] = None,
         model_parallel: Optional[bool] = None,
         default_optimizer: str = "adam",
+        max_ctx: int = 512,
     ):
         custom_kwargs = custom_kwargs or {}
         per_device_ram = torch.cuda.get_device_properties(0).total_memory
@@ -106,6 +116,7 @@ class ModelConfig:
         self.gradient_checkpointing = gradient_checkpointing
         self.model_parallel = model_parallel
         self.default_optimizer = default_optimizer
+        self.max_ctx = max_ctx
 
 
 MODELS_DICT: dict[str, ModelConfig] = {


### PR DESCRIPTION
In anticipation for lots of new models when investigating scaling laws, I have taken the opportunity to simplify the model configs:

- Migrated config dicts to yaml
- Added memory requirements to model config
- Set model_parallel, gradient_checkpointing programatically based on size
- Moved default minibatch size to model config class
- Added docstring to model config class